### PR TITLE
Enabled Zeus by Default

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -49,7 +49,7 @@ class Params {
         title = "Add Zeus";
         texts[] = {"Default","Yes"};
         values[] = {0,1};
-        default = 0;
+        default = 1;
     };
 };
 


### PR DESCRIPTION
Enabled **Zeus** by default for the server admins easily prevent some **ARMA** things 

## Why we need it? 

Because Arma happens and sometimes console commands are not enough.

## Does it works? 

Yes. I checked and it works. 